### PR TITLE
Fix verbose flag handling in copy_local

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 pub fn copy_local(src: &str, dest: &str, verbose: bool) -> io::Result<()> {
     let src_path = Path::new(src);
     let dest_path = Path::new(dest);
-    eprintln!("🔍 current dir = {}", std::env::current_dir()?.display());
+    if verbose {
+        eprintln!("copilot-context: current dir = {}", std::env::current_dir()?.display());
+    }
     if !src_path.exists() {
         println!(
             "copilot-context: source path '{}' does not exist",
@@ -18,13 +20,10 @@ pub fn copy_local(src: &str, dest: &str, verbose: bool) -> io::Result<()> {
     }
     if src_path.is_file() {
         fs::create_dir_all(dest_path.parent().unwrap())?;
-        println!("copilot-context: copying file {} -> {}", src, dest);
-        println!("dest_path.exists() = {}", dest_path.exists());
-        println!(
-            "dest_path.parent().unwrap() = {}",
-            dest_path.parent().unwrap().display()
-        );
-        fs::copy(src_path, dest_path).expect("Failed to copy file");
+        if verbose {
+            println!("copilot-context: copying file {} -> {}", src, dest);
+        }
+        fs::copy(src_path, dest_path)?;
     } else if src_path.is_dir() {
         copy_dir_all(src_path, dest_path, verbose)?;
     }


### PR DESCRIPTION
## Summary
- make the debug output in `copy_local` conditional on the verbose flag
- propagate I/O errors instead of panicking

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684d786f68788322a99c9583189f961b