### PR TITLE
Add agent instructions for local CI

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,8 @@
+# Instructions for Codex Agents
+
+To mirror the linting and testing steps used in CI, replicate the setup from the GitHub Actions workflows.
+
+1. Review `.github/workflows/build-test.yml` for how the stable Rust toolchain with `clippy` and `rustfmt` is installed and which commands are run.
+2. For platform-specific dependencies (such as OpenSSL) see `.github/workflows/release.yml`.
+
+Run the same commands locally to ensure your environment matches the CI configuration.


### PR DESCRIPTION
## Summary
- update instructions in `agent.md` to point at CI workflows for setup steps

## Testing
- `cargo test --all-features --locked --verbose`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_68536e0c5fc88322b99cd64137943675