### PR TITLE
Fix verbose flag handling in copy_local

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -5,9 +5,14 @@ use std::path::Path;
 pub fn copy_local(src: &str, dest: &str, verbose: bool) -> io::Result<()> {
     let src_path = Path::new(src);
     let dest_path = Path::new(dest);
-    eprintln!("🔍 current dir = {}", std::env::current_dir()?.display());
+    if verbose {
+        eprintln!(
+            "copilot-context: current dir = {}",
+            std::env::current_dir()?.display()
+        );
+    }
     if !src_path.exists() {
-        println!(
+        eprintln!(
             "copilot-context: source path '{}' does not exist",
             src_path.display()
         );
@@ -18,13 +23,10 @@ pub fn copy_local(src: &str, dest: &str, verbose: bool) -> io::Result<()> {
     }
     if src_path.is_file() {
         fs::create_dir_all(dest_path.parent().unwrap())?;
-        println!("copilot-context: copying file {} -> {}", src, dest);
-        println!("dest_path.exists() = {}", dest_path.exists());
-        println!(
-            "dest_path.parent().unwrap() = {}",
-            dest_path.parent().unwrap().display()
-        );
-        fs::copy(src_path, dest_path).expect("Failed to copy file");
+        if verbose {
+            println!("copilot-context: copying file {} -> {}", src, dest);
+        }
+        fs::copy(src_path, dest_path)?;
     } else if src_path.is_dir() {
         copy_dir_all(src_path, dest_path, verbose)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,9 @@ fn main() {
                     .as_path()
                     .to_str()
                     .expect("Failed to convert path to string");
-                println!("copilot-context: absolute source path: {}", abs_source_str);
+                if cli.verbose {
+                    println!("copilot-context: absolute source path: {}", abs_source_str);
+                }
                 if let Err(e) = copy::copy_local(abs_source_str, &dest, cli.verbose) {
                     eprintln!("copilot-context: error copying path {}: {}", name, e);
                 }


### PR DESCRIPTION
## Summary
- make verbose path log conditional
- log missing source path errors to stderr

## Testing
- `cargo test --all --quiet`
- `find . -name "*.rs" -print0 | xargs -0 rustfmt --check`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d786f68788322a99c9583189f961b